### PR TITLE
fix: share link

### DIFF
--- a/src/components/StageShareMenu.tsx
+++ b/src/components/StageShareMenu.tsx
@@ -1,11 +1,19 @@
-import React, { useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Share2, MessageCircle, Facebook, Copy, Check, ExternalLink } from 'lucide-react';
-import { toast } from 'sonner';
-import { useScreenSize } from '@/hooks/use-mobile';
-import { supabase } from '@/integrations/supabase/client';
+import React, { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Share2,
+  MessageCircle,
+  Facebook,
+  Copy,
+  Check,
+  ExternalLink,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useScreenSize } from "@/hooks/use-mobile";
+import { supabase } from "@/integrations/supabase/client";
+import { brandUrl } from "@/lib/brand";
 
 interface StageShareMenuProps {
   eventId: string;
@@ -13,14 +21,16 @@ interface StageShareMenuProps {
   eventDescription?: string;
 }
 
-const StageShareMenu: React.FC<StageShareMenuProps> = ({ 
-  eventId, 
-  eventTitle, 
-  eventDescription 
+const StageShareMenu: React.FC<StageShareMenuProps> = ({
+  eventId,
+  eventTitle,
+  eventDescription,
 }) => {
-  const [copiedStates, setCopiedStates] = useState<{ [key: string]: boolean }>({});
+  const [copiedStates, setCopiedStates] = useState<{ [key: string]: boolean }>(
+    {}
+  );
   const [isGeneratingToken, setIsGeneratingToken] = useState(false);
-  const [eventSlug, setEventSlug] = useState<string>('');
+  const [eventSlug, setEventSlug] = useState<string>("");
   const screenSize = useScreenSize();
 
   // Fetch event slug for better URLs
@@ -28,47 +38,59 @@ const StageShareMenu: React.FC<StageShareMenuProps> = ({
     const fetchEventSlug = async () => {
       try {
         const { data } = await supabase
-          .from('events')
-          .select('slug')
-          .eq('id', eventId)
+          .from("events")
+          .select("slug")
+          .eq("id", eventId)
           .single();
-        
+
         if (data?.slug) {
           setEventSlug(data.slug);
         }
       } catch (error) {
-        console.log('Could not fetch event slug:', error);
+        console.log("Could not fetch event slug:", error);
       }
     };
-    
+
     fetchEventSlug();
   }, [eventId]);
 
   const generateSecureInviteLink = async (): Promise<string> => {
     try {
       setIsGeneratingToken(true);
-      
-      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+
+      const {
+        data: { session },
+        error: sessionError,
+      } = await supabase.auth.getSession();
       if (sessionError || !session) {
-        throw new Error('Please log in to generate invite links');
+        throw new Error("Please log in to generate invite links");
       }
 
-      const { data, error } = await supabase.functions.invoke('generate-streamer-invite-token', {
-        body: { eventId },
-        headers: {
-          Authorization: `Bearer ${session.access_token}`,
-        },
-      });
+      const { data, error } = await supabase.functions.invoke(
+        "generate-streamer-invite-token",
+        {
+          body: { eventId },
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+          },
+        }
+      );
 
       if (error) {
-        throw new Error(error.message || 'Failed to generate secure invite link');
+        throw new Error(
+          error.message || "Failed to generate secure invite link"
+        );
       }
 
       const stageIdentifier = eventSlug || eventId;
       return `${window.location.origin}/stage/${stageIdentifier}?token=${data.token}`;
     } catch (error) {
-      console.error('Error generating secure invite link:', error);
-      toast.error(error instanceof Error ? error.message : 'Failed to generate secure invite link');
+      console.error("Error generating secure invite link:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to generate secure invite link"
+      );
       // Fallback to basic URL
       const stageIdentifier = eventSlug || eventId;
       return `${window.location.origin}/stage/${stageIdentifier}`;
@@ -77,137 +99,153 @@ const StageShareMenu: React.FC<StageShareMenuProps> = ({
     }
   };
 
-  const stageUrl = `${window.location.origin}/stage/${eventSlug || eventId}`;
-  
+  const stageUrl = `${brandUrl}/stage/${eventSlug || eventId}`;
+
   // Create secure share message function that generates token for each use
   const createSecureShareMessage = async (): Promise<string> => {
     const secureUrl = await generateSecureInviteLink();
-    return `Join me for a live streaming event: "${eventTitle}"\n\n${eventDescription ? eventDescription + '\n\n' : ''}Access the stage here: ${secureUrl}`;
+    return `Join me for a live streaming event: "${eventTitle}"\n\n${
+      eventDescription ? eventDescription + "\n\n" : ""
+    }Access the stage here: ${secureUrl}`;
   };
 
   const shareOptions = [
     {
-      id: 'whatsapp',
-      name: 'WhatsApp',
+      id: "whatsapp",
+      name: "WhatsApp",
       icon: MessageCircle,
-      color: 'bg-green-500',
+      color: "bg-green-500",
       action: async () => {
         const secureMessage = await createSecureShareMessage();
-        const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(secureMessage)}`;
-        window.open(whatsappUrl, '_blank');
-        toast.success('WhatsApp opened with secure stage invitation');
-      }
+        const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(
+          secureMessage
+        )}`;
+        window.open(whatsappUrl, "_blank");
+        toast.success("WhatsApp opened with secure stage invitation");
+      },
     },
     {
-      id: 'facebook',
-      name: 'Facebook Messenger',
+      id: "facebook",
+      name: "Facebook Messenger",
       icon: Facebook,
-      color: 'bg-blue-600',
+      color: "bg-blue-600",
       action: async () => {
         const secureMessage = await createSecureShareMessage();
-        const messengerUrl = `https://m.me/?text=${encodeURIComponent(secureMessage)}`;
-        window.open(messengerUrl, '_blank');
-        toast.success('Facebook Messenger opened with secure stage invitation');
-      }
+        const messengerUrl = `https://m.me/?text=${encodeURIComponent(
+          secureMessage
+        )}`;
+        window.open(messengerUrl, "_blank");
+        toast.success("Facebook Messenger opened with secure stage invitation");
+      },
     },
     {
-      id: 'instagram',
-      name: 'Instagram',
+      id: "instagram",
+      name: "Instagram",
       icon: Share2,
-      color: 'bg-gradient-to-r from-purple-500 to-pink-500',
+      color: "bg-gradient-to-r from-purple-500 to-pink-500",
       action: async () => {
         const secureMessage = await createSecureShareMessage();
         navigator.clipboard.writeText(secureMessage).then(() => {
-          window.open('https://www.instagram.com/direct/inbox/', '_blank');
-          toast.success('Secure invitation message copied! Paste in Instagram DM');
+          window.open("https://www.instagram.com/direct/inbox/", "_blank");
+          toast.success(
+            "Secure invitation message copied! Paste in Instagram DM"
+          );
         });
-      }
+      },
     },
     {
-      id: 'tiktok',
-      name: 'TikTok',
+      id: "tiktok",
+      name: "TikTok",
       icon: MessageCircle,
-      color: 'bg-black',
+      color: "bg-black",
       action: async () => {
         const secureMessage = await createSecureShareMessage();
         navigator.clipboard.writeText(secureMessage).then(() => {
-          window.open('https://www.tiktok.com/messages', '_blank');
-          toast.success('Secure invitation message copied! Paste in TikTok DM');
+          window.open("https://www.tiktok.com/messages", "_blank");
+          toast.success("Secure invitation message copied! Paste in TikTok DM");
         });
-      }
+      },
     },
     {
-      id: 'twitter',
-      name: 'X (Twitter)',
+      id: "twitter",
+      name: "X (Twitter)",
       icon: MessageCircle,
-      color: 'bg-black',
+      color: "bg-black",
       action: async () => {
         const secureMessage = await createSecureShareMessage();
-        const twitterUrl = `https://twitter.com/messages/compose?text=${encodeURIComponent(secureMessage)}`;
-        window.open(twitterUrl, '_blank');
-        toast.success('X opened with secure stage invitation');
-      }
+        const twitterUrl = `https://twitter.com/messages/compose?text=${encodeURIComponent(
+          secureMessage
+        )}`;
+        window.open(twitterUrl, "_blank");
+        toast.success("X opened with secure stage invitation");
+      },
     },
     {
-      id: 'copy',
-      name: 'Copy Secure Link',
-      icon: copiedStates['copy'] ? Check : Copy,
-      color: copiedStates['copy'] ? 'bg-green-600' : 'bg-gray-600',
+      id: "copy",
+      name: "Copy Secure Link",
+      icon: copiedStates["copy"] ? Check : Copy,
+      color: copiedStates["copy"] ? "bg-green-600" : "bg-gray-600",
       action: async () => {
         const secureUrl = await generateSecureInviteLink();
-        navigator.clipboard.writeText(secureUrl).then(() => {
-          setCopiedStates(prev => ({ ...prev, copy: true }));
-          toast.success('Secure invite link copied to clipboard');
-          setTimeout(() => {
-            setCopiedStates(prev => ({ ...prev, copy: false }));
-          }, 2000);
-        }).catch(() => {
-          // Fallback for older browsers
-          const textArea = document.createElement('textarea');
-          textArea.value = secureUrl;
-          document.body.appendChild(textArea);
-          textArea.select();
-          document.execCommand('copy');
-          document.body.removeChild(textArea);
-          
-          setCopiedStates(prev => ({ ...prev, copy: true }));
-          toast.success('Secure invite link copied to clipboard');
-          setTimeout(() => {
-            setCopiedStates(prev => ({ ...prev, copy: false }));
-          }, 2000);
-        });
-      }
+        navigator.clipboard
+          .writeText(secureUrl)
+          .then(() => {
+            setCopiedStates((prev) => ({ ...prev, copy: true }));
+            toast.success("Secure invite link copied to clipboard");
+            setTimeout(() => {
+              setCopiedStates((prev) => ({ ...prev, copy: false }));
+            }, 2000);
+          })
+          .catch(() => {
+            // Fallback for older browsers
+            const textArea = document.createElement("textarea");
+            textArea.value = secureUrl;
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand("copy");
+            document.body.removeChild(textArea);
+
+            setCopiedStates((prev) => ({ ...prev, copy: true }));
+            toast.success("Secure invite link copied to clipboard");
+            setTimeout(() => {
+              setCopiedStates((prev) => ({ ...prev, copy: false }));
+            }, 2000);
+          });
+      },
     },
     {
-      id: 'copy-message',
-      name: 'Copy Message',
-      icon: copiedStates['copy-message'] ? Check : Copy,
-      color: copiedStates['copy-message'] ? 'bg-green-600' : 'bg-purple-600',
+      id: "copy-message",
+      name: "Copy Message",
+      icon: copiedStates["copy-message"] ? Check : Copy,
+      color: copiedStates["copy-message"] ? "bg-green-600" : "bg-purple-600",
       action: async () => {
         const secureMessage = await createSecureShareMessage();
-        navigator.clipboard.writeText(secureMessage).then(() => {
-          setCopiedStates(prev => ({ ...prev, 'copy-message': true }));
-          toast.success('Secure invitation message copied');
-          setTimeout(() => {
-            setCopiedStates(prev => ({ ...prev, 'copy-message': false }));
-          }, 2000);
-        }).catch(() => {
-          // Fallback for older browsers
-          const textArea = document.createElement('textarea');
-          textArea.value = secureMessage;
-          document.body.appendChild(textArea);
-          textArea.select();
-          document.execCommand('copy');
-          document.body.removeChild(textArea);
-          
-          setCopiedStates(prev => ({ ...prev, 'copy-message': true }));
-          toast.success('Secure invitation message copied');
-          setTimeout(() => {
-            setCopiedStates(prev => ({ ...prev, 'copy-message': false }));
-          }, 2000);
-        });
-      }
-    }
+        navigator.clipboard
+          .writeText(secureMessage)
+          .then(() => {
+            setCopiedStates((prev) => ({ ...prev, "copy-message": true }));
+            toast.success("Secure invitation message copied");
+            setTimeout(() => {
+              setCopiedStates((prev) => ({ ...prev, "copy-message": false }));
+            }, 2000);
+          })
+          .catch(() => {
+            // Fallback for older browsers
+            const textArea = document.createElement("textarea");
+            textArea.value = secureMessage;
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand("copy");
+            document.body.removeChild(textArea);
+
+            setCopiedStates((prev) => ({ ...prev, "copy-message": true }));
+            toast.success("Secure invitation message copied");
+            setTimeout(() => {
+              setCopiedStates((prev) => ({ ...prev, "copy-message": false }));
+            }, 2000);
+          });
+      },
+    },
   ];
 
   return (
@@ -215,21 +253,31 @@ const StageShareMenu: React.FC<StageShareMenuProps> = ({
       <CardHeader className="p-3 sm:p-3">
         <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
           <Share2 className="h-3 w-3 sm:h-4 sm:w-4" />
-          {screenSize === 'mobile' ? 'Invite Streamers' : 'Invite Other Streamers'}
+          {screenSize === "mobile"
+            ? "Invite Streamers"
+            : "Invite Other Streamers"}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3 sm:space-y-4 p-3 sm:p-3">
         <div className="space-y-2">
           <p className="text-xs sm:text-sm text-muted-foreground">
-            {screenSize === 'mobile' ? 'Share stage link:' : 'Share this stage link to invite other streamers to join your event:'}
+            {screenSize === "mobile"
+              ? "Share stage link:"
+              : "Share this stage link to invite other streamers to join your event:"}
           </p>
           <div className="flex items-center gap-2 p-2 bg-muted rounded-lg">
             <ExternalLink className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground flex-shrink-0" />
-            <span className="text-xs sm:text-sm font-mono truncate flex-1">{stageUrl}</span>
+            <span className="text-xs sm:text-sm font-mono truncate flex-1">
+              {stageUrl}
+            </span>
           </div>
         </div>
 
-        <div className={`grid gap-2 ${screenSize === 'mobile' ? 'grid-cols-1' : 'grid-cols-2'}`}>
+        <div
+          className={`grid gap-2 ${
+            screenSize === "mobile" ? "grid-cols-1" : "grid-cols-2"
+          }`}
+        >
           {shareOptions.map((option) => {
             const Icon = option.icon;
             return (
@@ -237,14 +285,21 @@ const StageShareMenu: React.FC<StageShareMenuProps> = ({
                 key={option.id}
                 onClick={option.action}
                 variant="outline"
-                className={`flex items-center gap-2 h-auto p-2 sm:p-3 ${screenSize === 'mobile' ? 'justify-start' : ''}`}
-                disabled={copiedStates[option.id] || (option.id === 'copy' && isGeneratingToken)}
-                size={screenSize === 'mobile' ? 'sm' : 'default'}
+                className={`flex items-center gap-2 h-auto p-2 sm:p-3 ${
+                  screenSize === "mobile" ? "justify-start" : ""
+                }`}
+                disabled={
+                  copiedStates[option.id] ||
+                  (option.id === "copy" && isGeneratingToken)
+                }
+                size={screenSize === "mobile" ? "sm" : "default"}
               >
                 <div className={`p-1 rounded ${option.color} flex-shrink-0`}>
                   <Icon className="h-3 w-3 text-white" />
                 </div>
-                <span className="text-xs sm:text-sm truncate">{option.name}</span>
+                <span className="text-xs sm:text-sm truncate">
+                  {option.name}
+                </span>
               </Button>
             );
           })}
@@ -255,7 +310,11 @@ const StageShareMenu: React.FC<StageShareMenuProps> = ({
             <Badge variant="secondary" className="text-xs">
               Host Only
             </Badge>
-            <span className="truncate">{screenSize === 'mobile' ? 'Private panel' : 'Only you can see this sharing panel'}</span>
+            <span className="truncate">
+              {screenSize === "mobile"
+                ? "Private panel"
+                : "Only you can see this sharing panel"}
+            </span>
           </div>
         </div>
       </CardContent>

--- a/src/lib/shareUtils.ts
+++ b/src/lib/shareUtils.ts
@@ -14,7 +14,7 @@ export function getShareableEventUrl(eventId: string, slug?: string): string {
 }
 
 export function getDirectEventUrl(eventId: string, slug?: string): string {
-  const baseUrl = window.location.origin;
+  const baseUrl = brandUrl;
   const eventIdentifier = slug || eventId;
 
   // Return direct event page URL (for internal navigation)


### PR DESCRIPTION
### Fix: Extra Slash in Generated Event URL

#### Related Issue
- Closes #27  


#### Problem
- `brandUrl` in `.env` contained a trailing `/`
- and we were using `return ${brandUrl}/event/${eventIdentifier}` 

> the issue was in the .env file


